### PR TITLE
fix: typo in width property and make highlights optional

### DIFF
--- a/lua/nvim-intro/intro.lua
+++ b/lua/nvim-intro/intro.lua
@@ -15,6 +15,7 @@ local defaults = {
     scratch = false,
     height = 6,
     width = 55,
+    highlights = {},
 }
 
 local M = {}
@@ -67,7 +68,7 @@ M.setup = function(options)
     options = options or {}
     M.options = vim.tbl_deep_extend("force", defaults, options)
     M.options.height = #M.options.intro
-    M.options.widht = vim.fn.strdisplaywidth(M.options.intro[1])
+    M.options.width = vim.fn.strdisplaywidth(M.options.intro[1])
     vim.api.nvim_set_hl(highlight_ns_id, "Minintro", { fg = M.options.color })
     vim.api.nvim_set_hl_ns(highlight_ns_id)
 


### PR DESCRIPTION
Hi,

Thanks for your work on making the original plugin more customizable, it was exactly what I was looking for! I was running into two small issues that I think this PR should fix:

I wasn't using the `highlights` property in the options, so I was getting this error

```
bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
        [C]: in function 'pairs'
        ...te/pack/packer/start/nvim-intro/lua/nvim-intro/intro.lua:32: in function 'matcher'
```

Also my text wasn't aligning correctly, which I suspect has to do with the typo in `width`